### PR TITLE
Fix bmx6 crashes with "Too many open files" error, closes #186.

### DIFF
--- a/tools.c
+++ b/tools.c
@@ -13,6 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301, USA
+ *
+ * Contributors:
+ *	Simó Albert i Beltran
  */
 
 #include <stdio.h>


### PR DESCRIPTION
This change fix bmx6 crashes with "Too many open files" error: http://qmp.cat/issues/186
