### PR TITLE
How to add uploaders

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: bmx6
 Section: net
 Priority: optional
 Maintainer: Steffen Moeller <moeller@debian.org>
-Uploaders: Axel Neumann <your@email.com>, Paul Spooren <your@email.com>
+Uploaders: Axel Neumann <neumann@cgws.de>, Paul Spooren <paul@makrotopia.org>
 Build-Depends: debhelper (>= 10),libjson-c-dev
 Standards-Version: 4.1.4
 Homepage: https://github.com/bmx-routing/bmx6

--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,7 @@ Source: bmx6
 Section: net
 Priority: optional
 Maintainer: Steffen Moeller <moeller@debian.org>
+Uploaders: Axel Neumann <your@email.com>, Paul Spooren <your@email.com>
 Build-Depends: debhelper (>= 10),libjson-c-dev
 Standards-Version: 4.1.4
 Homepage: https://github.com/bmx-routing/bmx6


### PR DESCRIPTION
Editing is allowed for maintainers. I propose you just edit this accordingly. There is no ultimate need for myself to appear as a maintainer. The maintainer could also be a virtual figure like a mailing list. But some human being should be around as an uploader, then.
To appear as uploader is also important for you to upload updates once the package is accepted in the distribution.
Best,
Steffen